### PR TITLE
Add CODEOWNERS and a PR template item for running the integration tests locally

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,2 @@
-# Each line is a file pattern followed by one or more owners.
-# These owners will be the default owners for everything in
-# the repo.
-*       @confluentinc/connect-team1
+* @pvallone @spanglerco
+

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -19,7 +19,7 @@
 ##### Testing done:
 - [ ] Unit tests
 - [ ] Integration tests
-- [ ] I manually ran the integration tests with `mvn install`
+- [ ] I manually ran the integration tests by running `mvn install`
 - [ ] System tests
 - [ ] Manual tests
 

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -19,7 +19,7 @@
 ##### Testing done:
 - [ ] Unit tests
 - [ ] Integration tests
-- [ ] I manually ran the integration tests locally
+- [ ] I manually ran the integration tests with `mvn install`
 - [ ] System tests
 - [ ] Manual tests
 

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -19,6 +19,7 @@
 ##### Testing done:
 - [ ] Unit tests
 - [ ] Integration tests
+- [ ] I manually ran the integration tests locally
 - [ ] System tests
 - [ ] Manual tests
 


### PR DESCRIPTION
## Problem
Until #2193397 is implemented, we have to rely on folks running the integration tests manually.

We also need a CODEOWNERS file.

## Solution
Added a PR template checkbox for running the integration tests manually. I snuck a CODEOWNERS file into this PR too.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [X] no

## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
~~- [ ] Unit tests~~
~~- [ ] Integration tests~~
~~- [ ] System tests~~
~~- [ ] Manual tests~~

~~## Release Plan~~
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
