### PR TITLE
Include both the start and end offset in the Kafka notification message

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@ This repo is based off of the `v10.2.2` tag from upstream.
 
 - Whenever a new file is committed to S3, the sink publishes information about
   that file to a Kafka topic:
+
   - Filename
-  - Number of rows in the file
-  - startOffset of the file
-  - The integration tests assume that they are connecting to an S3 bucket in the
-    `us-east-1` region
+  - The number of rows in the file
+  - The start and end offsets of the file
+
+- The integration tests assume that they are connecting to an S3 bucket in the
+  `us-east-1` region
 
 ---
 

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
@@ -656,6 +656,7 @@ public class TopicPartitionWriter {
                 filename,
                 filename,
                 startOffsets.get(encodedPartition),
+                endOffsets.get(encodedPartition),
                 recordCounts.get(encodedPartition));
       } catch (Exception e) {
         log.error("Error publishing Continuum notification to Kafka: {}", e.getMessage());

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/continuum/NewFileCommittedMessageBody.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/continuum/NewFileCommittedMessageBody.java
@@ -36,7 +36,10 @@ public class NewFileCommittedMessageBody {
   public NewFileCommittedMessageBody() {
   }
 
-  public NewFileCommittedMessageBody(String filename, long startOffset, long endOffset, long recordCount) {
+  public NewFileCommittedMessageBody(String filename,
+                                     long startOffset,
+                                     long endOffset,
+                                     long recordCount) {
     this.filename = filename;
     this.startOffset = startOffset;
     this.endOffset = endOffset;

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/continuum/NewFileCommittedMessageBody.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/continuum/NewFileCommittedMessageBody.java
@@ -24,8 +24,11 @@ public class NewFileCommittedMessageBody {
   @JsonProperty("filename")
   public String filename;
 
-  @JsonProperty("offset")
-  public long offset;
+  @JsonProperty("startOffset")
+  public long startOffset;
+
+  @JsonProperty("endOffset")
+  public long endOffset;
 
   @JsonProperty("recordCount")
   public long recordCount;
@@ -33,9 +36,10 @@ public class NewFileCommittedMessageBody {
   public NewFileCommittedMessageBody() {
   }
 
-  public NewFileCommittedMessageBody(String filename, long offset, long recordCount) {
+  public NewFileCommittedMessageBody(String filename, long startOffset, long endOffset, long recordCount) {
     this.filename = filename;
-    this.offset = offset;
+    this.startOffset = startOffset;
+    this.endOffset = endOffset;
     this.recordCount = recordCount;
   }
 }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/continuum/S3Continuum.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/continuum/S3Continuum.java
@@ -102,7 +102,7 @@ public class S3Continuum {
 
   public void produce(String key,
                       String filename,
-                      long startOffset, 
+                      long startOffset,
                       long endOffset,
                       long recordCount) {
     if (isActive()) {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/continuum/S3Continuum.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/continuum/S3Continuum.java
@@ -72,13 +72,19 @@ public class S3Continuum {
       this.producer = new KafkaProducer<>(producerProperties);
 
       if (usingAvro) {
+        // We provide defaults for startOffset and endOffset
+        // for compatibility with the original version of the schema
+        // which only included a field named "offset" representing
+        // the startOffset. The continuum always sets startOffset
+        // and endOffset, so the defaults are unused.
         String s3NotificationSchema =
                 "{\"type\":\"record\","
                         + "\"name\":\"new_file\","
                         + "\"namespace\":\"io.confluent.connect.s3.continuum\","
                         + "\"fields\":["
                         + "{\"name\":\"filename\",\"type\":\"string\"},"
-                        + "{\"name\":\"offset\",\"type\":\"long\"},"
+                        + "{\"name\":\"startOffset\",\"type\":\"long\", \"default\": 0},"
+                        + "{\"name\":\"endOffset\",\"type\":\"long\", \"default\": 0},"
                         + "{\"name\":\"recordCount\",\"type\":\"long\"}"
                         + "]}";
         Schema.Parser parser = new Schema.Parser();

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/continuum/S3Continuum.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/continuum/S3Continuum.java
@@ -100,19 +100,20 @@ public class S3Continuum {
     return this.producer != null;
   }
 
-  public void produce(String key, String filename, long offset, long recordCount) {
+  public void produce(String key, String filename, long startOffset, long endOffset, long recordCount) {
     if (isActive()) {
       boolean usingAvro = this.valueSchema != null;
       if (usingAvro) {
         GenericRecord value = new GenericData.Record(this.valueSchema);
         value.put("filename", filename);
-        value.put("offset", offset);
+        value.put("startOffset", startOffset);
+        value.put("endOffset", endOffset);
         value.put("recordCount", recordCount);
 
         this.producer.send(new ProducerRecord<>(this.topic, this.partition, key, value));
       } else {
         JsonNode value = this.mapper.valueToTree(
-          new NewFileCommittedMessageBody(filename, offset, recordCount));
+          new NewFileCommittedMessageBody(filename, startOffset, endOffset, recordCount));
 
         this.producer.send(new ProducerRecord<>(this.topic, this.partition, key, value));
       }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/continuum/S3Continuum.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/continuum/S3Continuum.java
@@ -83,8 +83,8 @@ public class S3Continuum {
                         + "\"namespace\":\"io.confluent.connect.s3.continuum\","
                         + "\"fields\":["
                         + "{\"name\":\"filename\",\"type\":\"string\"},"
-                        + "{\"name\":\"startOffset\",\"type\":\"long\", \"default\": 0},"
-                        + "{\"name\":\"endOffset\",\"type\":\"long\", \"default\": 0},"
+                        + "{\"name\":\"startOffset\",\"type\":\"long\", \"default\": -1},"
+                        + "{\"name\":\"endOffset\",\"type\":\"long\", \"default\": -1},"
                         + "{\"name\":\"recordCount\",\"type\":\"long\"}"
                         + "]}";
         Schema.Parser parser = new Schema.Parser();

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/continuum/S3Continuum.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/continuum/S3Continuum.java
@@ -100,7 +100,11 @@ public class S3Continuum {
     return this.producer != null;
   }
 
-  public void produce(String key, String filename, long startOffset, long endOffset, long recordCount) {
+  public void produce(String key,
+                      String filename,
+                      long startOffset, 
+                      long endOffset,
+                      long recordCount) {
     if (isActive()) {
       boolean usingAvro = this.valueSchema != null;
       if (usingAvro) {

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkConnectorIT.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkConnectorIT.java
@@ -366,7 +366,7 @@ public class S3SinkConnectorIT extends BaseConnectorIT {
 
     HashSet<String> expectedFileNamesCopy = new HashSet<>(expectedFileNames);
     ObjectMapper mapper = new ObjectMapper();
-    long offset = 0;
+    long startOffset = 0;
     for (ConsumerRecord<byte[], byte[]> record : continuumMessages) {
       String value = new String(record.value());
       try {
@@ -375,8 +375,9 @@ public class S3SinkConnectorIT extends BaseConnectorIT {
         assertTrue(expectedFileNamesCopy.contains(message.filename));
         expectedFileNamesCopy.remove(message.filename); // ensures filenames are distinct
 
-        assertEquals(offset, message.offset);
-        offset += expectedRecordsPerFile;
+        assertEquals(startOffset, message.startOffset);
+        assertTrue(message.endOffset >= (startOffset + message.recordCount - 1));
+        startOffset += expectedRecordsPerFile;
 
         assertEquals(expectedRecordsPerFile, message.recordCount);
 

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkConnectorIT.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkConnectorIT.java
@@ -376,6 +376,8 @@ public class S3SinkConnectorIT extends BaseConnectorIT {
         expectedFileNamesCopy.remove(message.filename); // ensures filenames are distinct
 
         assertEquals(startOffset, message.startOffset);
+        // This is just a loose >= check because it's possible for numbers to get
+        // skipped between startOffset and endOffset
         assertTrue(message.endOffset >= (startOffset + message.recordCount - 1));
         startOffset += expectedRecordsPerFile;
 


### PR DESCRIPTION
## Problem
It seems like we'll need both the start and end offsets for #2273886, so I'm adding them to the Kafka message.

## Solution
Add both the start and end offsets to the Kafka message. I think this is technically a breaking change (unless schema registry handles this for us, which it might), but we're doing it before we release this to customers, so I think it'll be alright. Maybe something weird happens if there's a message with the old format in the queue when the DFS tries to consume from it, but I can monitor for that after the update. We aren't likely to run into this.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [X] no

##### If yes, where?


## Test Strategy
I updated the integration tests to check the endOffset.

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [X] Integration tests
- [X] I manually ran the integration tests by running `mvn install`
- [ ] System tests
- [ ] Manual tests

## Release Plan
I'll update the DFS separately. I'll need to make some simple code changes to the code that parses the message.
